### PR TITLE
Allow bot on all communities

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -134,14 +134,6 @@ const bot = new LemmyBot({
   connection: {
     secondsBetweenPolls: 30
   },
-  federation: {
-    allowList: [
-      {
-        instance: INSTANCE,
-        communities: ['sandbox']
-      }
-    ]
-  },
   dbFile: 'db.sqlite3',
   handlers: {
     comment: {

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,12 @@
+[program:lemmycardbot]
+numprocs=1                     ; number of processes copies to start (default 1)
+numprocs_start=1               ; start ID at 1 (default 0)
+user=lemmy                     ; start as this user (default root)
+process_name=cardbot-%(process_num)s
+command=/var/repo/lemmy-cardfetcher-bot/node_modules/.bin/ts-node /var/repo/lemmy-cardfetcher-bot/src/bot.ts
+autorestart=true               ; when to restart if exited after running (def: unexpected)
+startretries=3                 ; max # of serial start failures when starting (default 3)
+stopsignal=QUIT                ; signal used to kill process (default TERM)
+stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
+redirect_stderr=true           ; redirect proc stderr to stdout (default false)
+stdout_logfile=/var/log/supervisor-lemmycardbot-%(process_num)s.log


### PR DESCRIPTION
Removed the allowlist, opening up to all communities on the instance. Added a supervisor config file to be used on the server.